### PR TITLE
INFDB-3214: add support for custom timeouts

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,8 @@
 ## what
 * Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
 * Use bullet points to be concise and to the point.
-
-## why
-* Provide the justifications for the changes (e.g. business case). 
 * Describe why these changes were made (e.g. why do these commits fix the problem?)
-* Use bullet points to be concise and to the point.
 
 ## references
-* Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
+* Link to any supporting github issues, JIRA or helpful documentation to add some context.
 * Use `closes #123`, if this PR closes a GitHub issue `#123`
-

--- a/main.tf
+++ b/main.tf
@@ -62,6 +62,12 @@ resource "aws_db_instance" "default" {
 
   monitoring_interval = var.monitoring_interval
   monitoring_role_arn = var.monitoring_role_arn
+
+  timeouts {
+    create = lookup(var.timeouts, "create", null)
+    update = lookup(var.timeouts, "update", null)
+    delete = lookup(var.timeouts, "delete", null)
+  }
 }
 
 resource "aws_db_parameter_group" "default" {

--- a/variables.tf
+++ b/variables.tf
@@ -10,6 +10,7 @@ variable "host_name" {
   description = "The DB host name created in Route53"
 }
 
+
 variable "security_group_ids" {
   type        = list(string)
   default     = []
@@ -301,4 +302,18 @@ variable "monitoring_role_arn" {
 variable "iam_database_authentication_enabled" {
   description = "Specifies whether or mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled"
   default     = false
+}
+
+variable "timeouts" {
+  description = <<-EOT
+    Update Terraform resource management timeouts. Allows longer operations like
+    storage changes or upgrades. Can be overridden with even longer values, but be
+    aware that other CI timeouts might also need to be increased.
+  EOT
+  type        = map(string)
+  default = {
+    create = "60m"
+    update = "90m"
+    delete = "60m"
+  }
 }


### PR DESCRIPTION
## what
- add variable `timeout` to allow user to specify a custom timeout.  Longer upgrades take longer than the default 30 or 60 minutes.

## references
- INFDB-3214